### PR TITLE
[chore] Better default config path for linux

### DIFF
--- a/lib/BetterDiscord.js
+++ b/lib/BetterDiscord.js
@@ -14,6 +14,7 @@ var _utils = require("./utils");
 var _utils2;
 var _bdIpc = require('electron').ipcMain;
 var _error = false;
+var _path = require('path');
 
 var _eol = require('os').EOL;
 
@@ -35,7 +36,11 @@ function BetterDiscord(mainWindow) {
 function createAndCheckData() {
     getUtils().log("Checking data/cache");
 
-    _cfg.dataPath = (_cfg.os == 'win32' ? process.env.APPDATA : _cfg.os == 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local') + '/BetterDiscord/';
+    _cfg.dataPath = _path.join(
+        _cfg.os == 'win32' ? process.env.APPDATA : 
+        _cfg.os == 'darwin' ? _path.join(process.env.HOME + '/Library/Preferences') : 
+        _path.join(process.env.HOME, ".config"), '/BetterDiscord/');
+    
     _cfg.userFile = _cfg.dataPath + 'user.json';
 
     try {


### PR DESCRIPTION
This changes the default config directiory set at installation time to ~/.config/BetterDiscord for Linux users, which is about 100% more likely to be writable by the user.